### PR TITLE
Feature/hold until date endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,11 @@ gem 'foreman'
 gem 'unicorn'
 gem 'honeybadger'
 
+# security updates suggested by GitHub
+gem "rack", ">= 1.6.11"
+gem "rack-protection", ">= 1.5.5"
+# end security updates
+
 group :development do
   gem 'pry'
   gem 'shotgun'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,8 +43,8 @@ GEM
     pry-byebug (3.3.0)
       byebug (~> 8.0)
       pry (~> 0.10)
-    rack (1.6.4)
-    rack-protection (1.5.3)
+    rack (1.6.11)
+    rack-protection (1.5.5)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -105,6 +105,8 @@ DEPENDENCIES
   i18n
   pry
   pry-byebug
+  rack (>= 1.6.11)
+  rack-protection (>= 1.5.5)
   rack-test
   rspec
   shotgun
@@ -117,4 +119,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.12.5
+   2.0.1

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+  web:
+    container_name: shipstation-integration
+    network_mode: bridge
+    environment:
+      - VIRTUAL_HOST=shipstation_integration.flowlink.io
+    build: .
+    volumes:
+      - .:/app
+    restart: always
+    logging:
+      driver: gcplogs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,9 @@
-version: '3'
+version: "3"
+
 services:
-  shipstation_integration:
+  shipstation-integration:
     build: .
-    image: shipstation-integration
-    environment:
-      - VIRTUAL_HOST=shipstation_integration.flowlink.io
-    restart: always
-    network_mode: bridge
+    ports:
+      - '3001:5000'
     volumes:
       - .:/app
-

--- a/shipstation_app.rb
+++ b/shipstation_app.rb
@@ -38,19 +38,30 @@ class ShipStationApp < EndpointBase::Sinatra::Base
 
   # REST API doc https://www.mashape.com/shipstation/shipstation
 
-  post '/add_shipment' do
-    # Shipstation wants orders and then it creates shipments. This integration assumes the
-    # shipments are already split and will just create "orders" that are identical to the
-    # storefront concept of a shipment.
-
-    order = populate_order(@payload[:shipment] || @payload[:order])
+  post '/update_order_hold_date' do
+    order = @payload[:shipment] || @payload[:order]
     options = {
       headers: ship_headers.merge("content-type" => "application/json"),
-      parameters: order.to_json
+      parameters: build_order_hold_date_payload(order).to_json
     }
+    response = ShipstationClient.request :post, "Orders/HoldUntil", options
+    result 200, "Order #{order[:orderKey]} updated with new hold date"
+  end
 
-    response = ShipstationClient.request :post, "Orders/CreateOrder", options
-    result 200, "Shipment transmitted to ShipStation: #{response.body["orderId"]}"
+
+  # Shipstation wants orders and then it creates shipments. This integration assumes the
+  # shipments are already split and will just create "orders" that are identical to the
+  # storefront concept of a shipment.
+  post '/add_shipment' do
+    response = add_order_or_shipment(@payload[:shipment])
+    add_object :shipment, return_order
+    result 200, "Shipment transmitted to ShipStation: #{response[:shipstation_id]}"
+  end
+
+  post '/add_order' do
+    response = add_order_or_shipment(@payload[:order])
+    add_object :order, response
+    result 200, "Order transmitted to ShipStation: #{response[:shipstation_id]}"
   end
 
   # Error response.body examples:
@@ -148,6 +159,20 @@ class ShipStationApp < EndpointBase::Sinatra::Base
 
   private
 
+  def add_order_or_shipment(order_or_shipment)
+    order = populate_order(order_or_shipment)
+    options = {
+      headers: ship_headers.merge("content-type" => "application/json"),
+      parameters: order.to_json
+    }
+
+    response = ShipstationClient.request :post, "Orders/CreateOrder", options
+    order_or_shipment[:shipstation_id] = response.body["orderId"]
+    order_or_shipment[:orderKey] = response.body["orderKey"]
+
+    order_or_shipment
+  end
+
   def since_time
     Time.zone = ZONE
     Time.zone.parse(@config[:since])
@@ -156,6 +181,19 @@ class ShipStationApp < EndpointBase::Sinatra::Base
   def since_time_formatted
     datetime = since_time
     datetime.strftime("%Y-%m-%d %H:%M:%S")
+  end
+
+  def hold_until_date_formatted(order)
+    Time.zone = ZONE
+    hold_time = Time.zone.parse(order[:hold_until_date])
+    hold_time.strftime("%Y-%m-%d")
+  end
+
+  def build_order_hold_date_payload(order)
+    {
+      orderId: order[:orderKey],
+      holdUntilDate: hold_until_date_formatted(order)
+    }
   end
 
   def map_carrier(carrier_name)
@@ -189,6 +227,7 @@ class ShipStationApp < EndpointBase::Sinatra::Base
   end
 
   def populate_order(shipment)
+    puts shipment
     order = {
       "customerEmail" => shipment[:email],
       "customerUsername" => shipment[:email],
@@ -205,6 +244,10 @@ class ShipStationApp < EndpointBase::Sinatra::Base
       "advancedOptions" => populate_advanced(shipment),
       "items" => populate_items(shipment[:items])
     }
+
+    if shipment[:orderKey]
+      order["orderKey"] = shipment[:orderKey]
+    end
 
     if shipment[:ship_by_date]
       order["shipByDate"] = shipment[:ship_by_date]

--- a/shipstation_app.rb
+++ b/shipstation_app.rb
@@ -227,7 +227,6 @@ class ShipStationApp < EndpointBase::Sinatra::Base
   end
 
   def populate_order(shipment)
-    puts shipment
     order = {
       "customerEmail" => shipment[:email],
       "customerUsername" => shipment[:email],

--- a/shipstation_app.rb
+++ b/shipstation_app.rb
@@ -45,7 +45,7 @@ class ShipStationApp < EndpointBase::Sinatra::Base
       parameters: build_order_hold_date_payload(order).to_json
     }
     response = ShipstationClient.request :post, "Orders/HoldUntil", options
-    result 200, "Order #{order[:orderKey]} updated with new hold date"
+    result 200, "Order #{order[:shipstation_id]} updated with new hold date"
   end
 
 
@@ -191,7 +191,7 @@ class ShipStationApp < EndpointBase::Sinatra::Base
 
   def build_order_hold_date_payload(order)
     {
-      orderId: order[:orderKey],
+      orderId: order[:shipstation_id],
       holdUntilDate: hold_until_date_formatted(order)
     }
   end


### PR DESCRIPTION
Adds hold order until date endpoint
Adds orderKey to return object to prevent duplicate creation
Adds shipstationId to return object for help in updating on later requests.
Refactors order objects out of /add_shipment endpoint to and moves to it's own /add_order endpoint